### PR TITLE
Implement document analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains a simple skeleton for a multi-module platform. Modules 
 - **Door Access Control Module**: manage door hardware and settings
 - **IoT Module**: receive IoT signals via API or MQTT
 - **Visitor Registration Module**
+- **Document Analyzer Module**: upload and analyze files via OpenRouter
 
 The IoT module now exposes simple MQTT helper endpoints so that external
 vendors can push messages to the system. Door access synchronization state is
@@ -24,8 +25,9 @@ Each module can be expanded as development continues.
 cd backend
 python3 -m venv venv
 source venv/bin/activate
-pip install fastapi uvicorn sqlmodel
+pip install fastapi uvicorn sqlmodel requests
 uvicorn main:app --reload
 ```
 
 The backend persists customer and visitor data to a local SQLite database (`codex.db`). It also provides endpoints to ingest IoT data and sync door access settings.
+The Document Analyzer module exposes `/analyze` for uploading files and `/documents` to list past analyses.

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,8 @@ This is a minimal FastAPI backend exposing placeholder endpoints for each module
 - `/iot/mqtt` – publish an MQTT message (`POST`)
 - `/iot/mqtt/messages` – list received MQTT messages (`GET`)
 - `/visitors` – visitor registration (`GET`/`POST`)
+- `/analyze` - upload a document and return analysis
+- `/documents` - list analyzed documents
 
 ## Development
 
@@ -20,7 +22,7 @@ This is a minimal FastAPI backend exposing placeholder endpoints for each module
    ```
 2. Install dependencies:
    ```bash
-   pip install fastapi uvicorn sqlmodel
+   pip install fastapi uvicorn sqlmodel requests
    ```
 3. Run the development server (this will create a local SQLite
    database `codex.db` on first run):

--- a/backend/analyzer.py
+++ b/backend/analyzer.py
@@ -1,0 +1,26 @@
+import os
+import requests
+
+OPENROUTER_API_KEY = "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"
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def extract_text(data: bytes) -> str:
+    """Decode bytes to text, ignoring errors."""
+    return data.decode("utf-8", errors="ignore")
+
+
+def analyze_text(prompt: str, text: str) -> str:
+    """Send the prompt and text to OpenRouter and return the result."""
+    headers = {"Authorization": f"Bearer {OPENROUTER_API_KEY}", "Content-Type": "application/json"}
+    payload = {
+        "model": "openai/gpt-3.5-turbo",
+        "messages": [
+            {"role": "system", "content": "You are a helpful document analyzer."},
+            {"role": "user", "content": f"{prompt}\n\n{text}"}
+        ]
+    }
+    response = requests.post(OPENROUTER_URL, headers=headers, json=payload, timeout=30)
+    response.raise_for_status()
+    result = response.json()
+    return result.get("choices", [{}])[0].get("message", {}).get("content", "")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,12 @@
-from fastapi import FastAPI, HTTPException
-from typing import List
+from fastapi import FastAPI, HTTPException, UploadFile, File, Form
+from typing import List, Optional
 from sqlmodel import Field, Session, SQLModel, select
 
 from database import init_db, get_session
+import os
 
 from iot_mqtt import MQTTClient
+from analyzer import extract_text, analyze_text
 
 app = FastAPI(title="Codex Platform API")
 
@@ -15,6 +17,8 @@ mqtt_client = MQTTClient()
 # Initialize SQLite database
 init_db()
 
+UPLOAD_DIR = "uploads"
+os.makedirs(UPLOAD_DIR, exist_ok=True)
 class Customer(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str
@@ -33,6 +37,13 @@ class MQTTPublish(SQLModel):
 class Visitor(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str
+
+class Document(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    filename: str
+    path: str
+    prompt: Optional[str] = None
+    result: Optional[str] = None
 
 @app.get("/")
 def read_root():
@@ -89,6 +100,28 @@ def publish_iot_message(msg: MQTTPublish):
 def list_iot_messages():
     """Return MQTT messages received via the placeholder client."""
     return mqtt_client.messages
+# --- Document Analyzer Module ---
+@app.post("/analyze", response_model=Document)
+async def analyze_document(file: UploadFile = File(...), prompt: str = Form("")):
+    data = await file.read()
+    text = extract_text(data)
+    result = analyze_text(prompt, text)
+    path = os.path.join(UPLOAD_DIR, file.filename)
+    with open(path, "wb") as f:
+        f.write(data)
+    doc = Document(filename=file.filename, path=path, prompt=prompt, result=result)
+    with get_session() as session:
+        session.add(doc)
+        session.commit()
+        session.refresh(doc)
+        return doc
+
+@app.get("/documents", response_model=List[Document])
+def list_documents():
+    with get_session() as session:
+        docs = session.exec(select(Document)).all()
+        return docs
+
 
 # --- Visitor Registration Module ---
 


### PR DESCRIPTION
## Summary
- add new Document Analyzer module using OpenRouter API
- expose `/analyze` and `/documents` endpoints
- record uploads to `uploads/` and store results in SQLite
- document new module in READMEs

## Testing
- `python3 -m py_compile backend/*.py`
- `PYTHONPATH=backend python3 - <<'EOF'
import main
print('app loaded', hasattr(main, 'app'))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6840f00a4d18832fb4d4f9a1857dbba6