### PR TITLE
Implement document analyzer portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ This repository contains a simple skeleton for a multi-module platform. Modules 
 - **Door Access Control Module**: manage door hardware and settings
 - **IoT Module**: receive IoT signals via API or MQTT
 - **Visitor Registration Module**
+- **Document Analyzer Module**: upload and analyze files via OpenRouter
+
+The Document Analyzer accepts PDF, Word or text files. A small React portal in
+`frontend/` lets you select the backend URL, upload a document with an optional
+prompt and analysis type, then view the returned analysis. Uploaded files are
+written to an `uploads/` directory on the backend and results are stored in the
+same SQLite database that holds customer and visitor records. Text extraction is
+handled using **PyPDF2** and **python-docx**. The OpenRouter API key is read from
+the `OPENROUTER_API_KEY` environment variable or the default in
+`backend/analyzer.py`.
 
 The IoT module now exposes simple MQTT helper endpoints so that external
 vendors can push messages to the system. Door access synchronization state is
@@ -14,7 +24,7 @@ tracked in-memory for demonstration purposes.
 ## Structure
 
 - `backend/` – FastAPI backend exposing module endpoints
-- `frontend/` – React placeholder app
+- `frontend/` – React app with a simple document upload portal
 
 Each module can be expanded as development continues.
 
@@ -24,8 +34,20 @@ Each module can be expanded as development continues.
 cd backend
 python3 -m venv venv
 source venv/bin/activate
-pip install fastapi uvicorn sqlmodel
+pip install fastapi uvicorn sqlmodel requests PyPDF2 python-docx
 uvicorn main:app --reload
 ```
 
 The backend persists customer and visitor data to a local SQLite database (`codex.db`). It also provides endpoints to ingest IoT data and sync door access settings.
+The Document Analyzer module exposes `/analyze` for uploading files and `/documents` to list past analyses.
+
+## Running the Frontend
+
+The frontend is a minimal React app. Install dependencies with `npm install` and
+start your preferred development server:
+
+```bash
+cd frontend
+npm install
+npm run start
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -10,6 +10,12 @@ This is a minimal FastAPI backend exposing placeholder endpoints for each module
 - `/iot/mqtt` – publish an MQTT message (`POST`)
 - `/iot/mqtt/messages` – list received MQTT messages (`GET`)
 - `/visitors` – visitor registration (`GET`/`POST`)
+- `/analyze` - upload a document and return analysis (fields `file`, `prompt`,
+  optional `analysis_type`)
+- `/documents` - list analyzed documents
+
+The analyzer extracts text from PDF and Word documents using PyPDF2 and
+python-docx.
 
 ## Development
 
@@ -20,7 +26,7 @@ This is a minimal FastAPI backend exposing placeholder endpoints for each module
    ```
 2. Install dependencies:
    ```bash
-   pip install fastapi uvicorn sqlmodel
+   pip install fastapi uvicorn sqlmodel requests PyPDF2 python-docx
    ```
 3. Run the development server (this will create a local SQLite
    database `codex.db` on first run):

--- a/backend/analyzer.py
+++ b/backend/analyzer.py
@@ -1,0 +1,46 @@
+import os
+from io import BytesIO
+import requests
+
+from PyPDF2 import PdfReader
+from docx import Document as DocxDocument
+
+OPENROUTER_API_KEY = os.getenv(
+    "OPENROUTER_API_KEY",
+    "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",
+)
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+
+def extract_text(data: bytes, filename: str) -> str:
+    """Return plain text from uploaded file data."""
+    ext = os.path.splitext(filename)[1].lower()
+    if ext == ".pdf":
+        try:
+            reader = PdfReader(BytesIO(data))
+            return "\n".join(page.extract_text() or "" for page in reader.pages)
+        except Exception:
+            pass
+    elif ext in {".doc", ".docx"}:
+        try:
+            doc = DocxDocument(BytesIO(data))
+            return "\n".join(p.text for p in doc.paragraphs)
+        except Exception:
+            pass
+    return data.decode("utf-8", errors="ignore")
+
+
+def analyze_text(prompt: str, text: str) -> str:
+    """Send the prompt and text to OpenRouter and return the result."""
+    headers = {"Authorization": f"Bearer {OPENROUTER_API_KEY}", "Content-Type": "application/json"}
+    payload = {
+        "model": "openai/gpt-3.5-turbo",
+        "messages": [
+            {"role": "system", "content": "You are a helpful document analyzer."},
+            {"role": "user", "content": f"{prompt}\n\n{text}"}
+        ]
+    }
+    response = requests.post(OPENROUTER_URL, headers=headers, json=payload, timeout=30)
+    response.raise_for_status()
+    result = response.json()
+    return result.get("choices", [{}])[0].get("message", {}).get("content", "")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,12 @@
-from fastapi import FastAPI, HTTPException
-from typing import List
+from fastapi import FastAPI, HTTPException, UploadFile, File, Form
+from typing import List, Optional
 from sqlmodel import Field, Session, SQLModel, select
 
 from database import init_db, get_session
+import os
 
 from iot_mqtt import MQTTClient
+from analyzer import extract_text, analyze_text
 
 app = FastAPI(title="Codex Platform API")
 
@@ -15,6 +17,8 @@ mqtt_client = MQTTClient()
 # Initialize SQLite database
 init_db()
 
+UPLOAD_DIR = "uploads"
+os.makedirs(UPLOAD_DIR, exist_ok=True)
 class Customer(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str
@@ -33,6 +37,14 @@ class MQTTPublish(SQLModel):
 class Visitor(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     name: str
+
+class Document(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    filename: str
+    path: str
+    prompt: Optional[str] = None
+    analysis_type: Optional[str] = None
+    result: Optional[str] = None
 
 @app.get("/")
 def read_root():
@@ -89,6 +101,39 @@ def publish_iot_message(msg: MQTTPublish):
 def list_iot_messages():
     """Return MQTT messages received via the placeholder client."""
     return mqtt_client.messages
+# --- Document Analyzer Module ---
+@app.post("/analyze", response_model=Document)
+async def analyze_document(
+    file: UploadFile = File(...),
+    prompt: str = Form(""),
+    analysis_type: str = Form(""),
+):
+    data = await file.read()
+    text = extract_text(data, file.filename)
+    final_prompt = f"{analysis_type}\n{prompt}" if analysis_type else prompt
+    result = analyze_text(final_prompt, text)
+    path = os.path.join(UPLOAD_DIR, file.filename)
+    with open(path, "wb") as f:
+        f.write(data)
+    doc = Document(
+        filename=file.filename,
+        path=path,
+        prompt=prompt or None,
+        analysis_type=analysis_type or None,
+        result=result,
+    )
+    with get_session() as session:
+        session.add(doc)
+        session.commit()
+        session.refresh(doc)
+        return doc
+
+@app.get("/documents", response_model=List[Document])
+def list_documents():
+    with get_session() as session:
+        docs = session.exec(select(Document)).all()
+        return docs
+
 
 # --- Visitor Registration Module ---
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,3 +1,12 @@
 # Frontend
 
-This is a placeholder React project. Install dependencies and run a dev server of your choice (e.g., Vite or Create React App).
+This React app provides a small portal for uploading documents to the backend
+analyzer. Enter the backend URL, choose a file, optionally supply a prompt and
+analysis type, and view the returned analysis.
+
+Run the app in development mode:
+
+```bash
+npm install
+npm run start
+```

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,10 +1,91 @@
-import React from 'react';
+import React, { useState } from 'react';
 
+/**
+ * Simple document analyzer portal. Allows selecting a backend URL,
+ * uploading a document with an optional prompt and analysis type,
+ * then viewing the returned analysis.
+ */
 function App() {
+  const [baseUrl, setBaseUrl] = useState('http://localhost:8000');
+  const [file, setFile] = useState(null);
+  const [prompt, setPrompt] = useState('');
+  const [analysisType, setAnalysisType] = useState('');
+  const [result, setResult] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!file) return;
+    setLoading(true);
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('prompt', prompt);
+    formData.append('analysis_type', analysisType);
+    try {
+      const res = await fetch(`${baseUrl}/analyze`, {
+        method: 'POST',
+        body: formData
+      });
+      const data = await res.json();
+      setResult(data.result || JSON.stringify(data));
+    } catch (err) {
+      setResult('Error contacting backend');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div>
-      <h1>Codex Platform</h1>
-      <p>Placeholder for UI</p>
+    <div style={{ padding: '1rem', fontFamily: 'sans-serif' }}>
+      <h1>Codex Document Analyzer</h1>
+
+      <div style={{ marginBottom: '1rem' }}>
+        <label>
+          Backend URL:
+          <input
+            type="text"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+            style={{ marginLeft: '0.5rem', width: '20rem' }}
+          />
+        </label>
+      </div>
+
+      <form onSubmit={handleSubmit}>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <input
+            type="file"
+            onChange={(e) => setFile(e.target.files[0])}
+          />
+        </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <input
+            type="text"
+            placeholder="Analysis type (optional)"
+            value={analysisType}
+            onChange={(e) => setAnalysisType(e.target.value)}
+            style={{ width: '20rem' }}
+          />
+        </div>
+        <div style={{ marginBottom: '0.5rem' }}>
+          <textarea
+            placeholder="Optional prompt"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            rows={3}
+            style={{ width: '20rem' }}
+          />
+        </div>
+        <button type="submit" disabled={loading}>Analyze</button>
+      </form>
+
+      {loading && <p>Analyzing...</p>}
+      {result && (
+        <div style={{ marginTop: '1rem', whiteSpace: 'pre-wrap' }}>
+          <h3>Result</h3>
+          <pre>{result}</pre>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- support PDF and Word extraction via PyPDF2 and python-docx
- add analysis_type field to Document model and `/analyze` endpoint
- expose environment variable for OpenRouter API key
- update React portal to send analysis type
- document setup in READMEs

## Testing
- `python3 -m py_compile backend/*.py`
- `PYTHONPATH=backend python3 - <<'EOF'
import main
print('app loaded', hasattr(main, 'app'))
EOF`
- `npm install` in `frontend/`
- `npm run start` in `frontend/`

------
https://chatgpt.com/codex/tasks/task_e_6840f00a4d18832fb4d4f9a1857dbba6